### PR TITLE
Add KGPrune: an API and Web application to extract subgraphs from Wikidata to bootstrap new KGs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -114,6 +114,7 @@
 ## Knowledge Engineering
 
 * [YAGA-NAGA](https://www.mpi-inf.mpg.de/departments/databases-and-information-systems/research/yago-naga/) - Harvesting, Searching, and Ranking Knowledge from the Web
+* [KGPrune](https://kgprune.loria.fr/) - An API and Web application for extracting subgraphs of interest from Wikidata based on user-input seed entities, to help bootstrap a new KG
 
 ### Knowledge Fusion
 


### PR DESCRIPTION
Dear all,

I have added to the list KGPrune, a new API and Web application to extract subgraphs of interest from Wikidata based on user-input seed entities. KGPrune starts from these seed entities, and keeps or prunes their neighboring entities to avoid topical drift and extract subgraphs related to the user domains of interest.

I hope this can be of interest for this repository.

Best,
Pierre
