### PR TITLE
Add Memgraph MCP Server to Graph Databases section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@
 * [Graphd](https://github.com/google/graphd) - the Metaweb/Freebase Graph Repository
 * [JanusGraph](http://janusgraph.org) - an open-source, distributed graph database with pluggable storage and indexing backends
 * [Memgraph](https://memgraph.com/) - High Performance, In-Memory, Transactional Graph Database
-* [Neo4j](http://tinkerpop.apache.org/docs/currentg/#neo4j-gremlin) - OLTP graph database
+* [Memgraph MCP Server](https://github.com/mgorunuch/memgraph-mcp-server) - Go implementation of Model Context Protocol server that enables AI assistants to interact with Memgraph graph databases* [Neo4j](http://tinkerpop.apache.org/docs/currentg/#neo4j-gremlin) - OLTP graph database
 * [Sparksee](http://www.sparsity-technologies.com/#sparksee) - makes space and performance compatible with a small footprint and a fast analysis of large networks
 * [Stardog](http://stardog.com/) - RDF graph database with OLTP and OLAP support
 * [OrientDB](http://orientdb.com/orientdb/) - Distributed Multi-Model NoSQL Database with a Graph Database Engine


### PR DESCRIPTION
This PR adds Memgraph MCP Server to the Graph Databases section. This is a Go implementation of Model Context Protocol server that enables AI assistants like Claude to interact with Memgraph graph databases, making it easier to build AI-powered knowledge graph applications.