### PR TITLE
Add AI Atlas Nexus to Other Domain knowledge graphs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -163,6 +163,7 @@
 * [Unified Medical Language System (UMLS)](https://www.nlm.nih.gov/research/umls/index.html) - The UMLS integrates and distributes key terminology, classification and coding standards, and associated resources to promote creation of more effective and interoperable biomedical information systems and services, including electronic health records.
 * [DrugBank](https://go.drugbank.com/) - Knowledge base for drug interactions, pharmacology, chemical structures, targets, metabolism, and more. 
 * [STRING](https://string-db.org/) - A database of known and predicted protein-protein interactions.
+* [AI Atlas Nexus](https://github.com/IBM/ai-atlas-nexus) - An open-source knowledge graph for AI risk governance that uses a LinkML ontology to unify risk taxonomies (NIST AI RMF, OWASP, EU AI Act, MIT) into a single graph linking risks, benchmarks, datasets, and mitigations. Supports Cypher export for Neo4j. From IBM Research.
 
 ## Learning Materials
 


### PR DESCRIPTION
Adds AI Atlas Nexus to the Other Domain section under Knowledge Graph Dataset.

AI Atlas Nexus is an open-source knowledge graph for AI risk governance from IBM Research. It uses a LinkML-based ontology to unify multiple AI risk taxonomies (NIST AI RMF, OWASP LLM Top 10, EU AI Act, MIT AI Risk Repository, IBM AI Risk Atlas) into a single knowledge graph, linking risks to benchmarks, datasets, and mitigations. The graph can be exported to Neo4j via Cypher.

This fits alongside the existing domain-specific knowledge graphs in this section (Lynx for legal compliance, UMLS for medical, DrugBank for pharma). AI Atlas Nexus fills a gap for the AI governance domain.

Apache 2.0 licensed, listed in the OECD AI Catalogue, 114 stars, active development.