### PR TITLE
Add FoJin - Buddhist studies knowledge graph

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -164,6 +164,7 @@
 * [Unified Medical Language System (UMLS)](https://www.nlm.nih.gov/research/umls/index.html) - The UMLS integrates and distributes key terminology, classification and coding standards, and associated resources to promote creation of more effective and interoperable biomedical information systems and services, including electronic health records.
 * [DrugBank](https://go.drugbank.com/) - Knowledge base for drug interactions, pharmacology, chemical structures, targets, metabolism, and more. 
 * [STRING](https://string-db.org/) - A database of known and predicted protein-protein interactions.
+* [FoJin](https://github.com/xr843/fojin) - A Buddhist studies knowledge graph with 9,600+ entities and 3,800+ relations covering people, texts, schools, monasteries, and concepts. Features interactive force-directed graph visualization and full-text search across 440+ sources.
 
 ## Learning Materials
 


### PR DESCRIPTION
Adding [FoJin](https://github.com/xr843/fojin) to the Other Domain section.

FoJin features a domain-specific knowledge graph for Buddhist studies with 9,600+ entities (people, texts, schools, monasteries, concepts, dynasties) and 3,800+ relations. It includes interactive force-directed graph visualization with D3 and supports multi-hop exploration.

Live demo: https://fojin.app/kg
GitHub: https://github.com/xr843/fojin