### PR TITLE
Add SwarmVault to Graph Construction

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -92,6 +92,7 @@
 * [Ontop](https://ontop-vkg.org/) - A Virtual Knowledge Graph engine for querying SQL data sources and transform SQL data sources through  R2RML mappings.
 * [Ontopic Studio](https://ontopic.ai/en/ontopic-studio/) - A commercially supported no code software for creating and maintaining large sets of R2RML mappings.
 * [Termboard](https://termboard.com/) - A very simple graphical editor to create Terms and Relations. It can use ChatGPT, Google Bard or any other chatbot. Ideal for beginners wanting to make and share quick sketches.
+* [SwarmVault](https://github.com/swarmclawai/swarmvault) - Local-first, open-source compiler that turns raw sources (books, notes, transcripts, files, URLs, code) into a durable markdown wiki with a typed knowledge graph and hybrid SQLite FTS plus embeddings. Includes an MCP server for AI assistants.
 
 ### Languages
 


### PR DESCRIPTION
[SwarmVault](https://github.com/swarmclawai/swarmvault) is an open-source, local-first compiler that turns raw sources (books, notes, transcripts, files, URLs, code) into a durable markdown wiki with a typed knowledge graph and hybrid SQLite FTS plus embeddings. It includes an MCP server so AI assistants like Claude, Codex, and Gemini CLI can query the graph, traverse paths, and explain relationships. Website at https://swarmvault.ai. MIT licensed.