### PR TITLE
Add KGLite to Graph Databases

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,7 @@
 * [TypeDB](https://vaticle.com/) - a database with a rich and logical type system. 
 * [Graphd](https://github.com/google/graphd) - the Metaweb/Freebase Graph Repository
 * [JanusGraph](http://janusgraph.org) - an open-source, distributed graph database with pluggable storage and indexing backends
+* [KGLite](https://kglite.readthedocs.io) - Embedded knowledge graph for Python written in Rust. Speaks openCypher, scales from in-memory to mmap to disk-backed CSR.
 * [Memgraph](https://memgraph.com/) - High Performance, In-Memory, Transactional Graph Database
 * [Neo4j](http://tinkerpop.apache.org/docs/currentg/#neo4j-gremlin) - OLTP graph database
 * [Sparksee](http://www.sparsity-technologies.com/#sparksee) - makes space and performance compatible with a small footprint and a fast analysis of large networks


### PR DESCRIPTION
Adds [KGLite](https://github.com/kkollsga/kglite) to the Graph Databases section, slotted alphabetically between JanusGraph and Memgraph.

KGLite is an embedded knowledge graph for Python written in Rust:
- openCypher query language
- Three storage modes (in-memory petgraph, mmap-backed columns, disk-backed CSR)
- pandas DataFrame I/O
- MIT-licensed, actively developed (latest release 0.8.26)

Docs: https://kglite.readthedocs.io