### PR TITLE
Add Dakera to Infrastructure — agent memory server with knowledge graph support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -51,6 +51,7 @@
 * [Kuzu](https://kuzudb.com/) - A highly scalable, extremely fast, and very easy-to-use embeddable graph database.
 * [CogDB](https://cogdb.io/) - A Micro Graph Database for Python Applications.
 * [TuGraph](https://www.tugraph.org/) - Graph database behinde Alipay. It has achieved the top-ranking performance in LDBC-SNB, a globally recognised benchmark test, surpassing competing solutions.
+* [Dakera](https://github.com/dakera-ai/dakera-mcp) - Self-hosted agent memory server with knowledge graph support for cross-agent knowledge sharing. Stores memories with entity relationships and decay-weighted recall. MCP-native, written in Rust.
 
 ### Triple Stores
 


### PR DESCRIPTION
## What

Adds [Dakera](https://github.com/dakera-ai/dakera-mcp) to the Infrastructure → Graph Databases section.

## Why

Dakera is a self-hosted agent memory server that stores memories as a knowledge graph with entity relationships and decay-weighted edges. It supports cross-agent entity sharing, making it a natural fit alongside graph database infrastructure tools.

Key properties:
- Memories are stored with typed entity relationships (people, places, organizations, concepts)
- Cross-agent knowledge sharing via a shared graph namespace
- Decay-weighted recall so older, less-reinforced memories fade naturally
- MCP-native (Model Context Protocol), written in Rust
- Self-hosted — no external API dependencies

This is a production-grade system for AI agent memory built on graph primitives, which aligns well with the infrastructure section of this list.