### PR TITLE
Add TWZRD Agent Intel to APIs and Services — trust scoring for graph reasoning agents

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -188,6 +188,11 @@
 
 * [Knowledge Graphs and LLMs in Action](https://www.manning.com/books/knowledge-graphs-and-llms-in-action) - a book that shows you how to introduce knowledge graphs constructed from structured and unstructured sources into LLM-powered applications and RAG pipelines.  
 
+
+## APIs and Services
+
+* [TWZRD Agent Intel](https://intel.twzrd.xyz) - Trust scoring for autonomous graph reasoning and data enrichment agents on Solana. MCP server for knowledge graph pipeline agent identity verification. Free: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`
+
 ## Contribute
 
 Contributions welcome! Read the [contribution guidelines](contributing.md) first.  


### PR DESCRIPTION
## Summary

- Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) under a new **APIs and Services** section
- Trust scoring for autonomous graph reasoning and data enrichment agents on Solana
- MCP server for knowledge graph pipeline agent identity verification

## Why this fits

Knowledge graph pipelines increasingly use autonomous agents for reasoning, enrichment, and traversal. TWZRD Agent Intel provides trust scoring for those agents via a standard MCP endpoint — allowing operators to verify agent wallet identity before graph operations.

**MCP config (zero-install):**
```json
{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}
```

Free tools: `score_agent(wallet)`, `preflight_check(wallet)`.