### PR TITLE
Add open-kgo to Graph Computing Frameworks

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -74,6 +74,7 @@
 * [RDFLib](https://rdflib.dev) - a pure Python RDF manipulation toolkit
 * [Redland C RDF](https://librdf.org/) - a set of free software C libraries that provide support for the Resource Description Framework (RDF)
 * [Tencent Plato](https://github.com/tencent/plato) - a fast distributed graph computation and machine learning framework used by WeChat
+* [open-kgo](https://github.com/mloda-ai/open-kgo) - a Python framework giving one API over nine knowledge-graph backend families, with ontology validation that rejects semantically invalid traversals
 
 ### Graph Visualization
 


### PR DESCRIPTION
Adds [open-kgo](https://github.com/mloda-ai/open-kgo) under Infrastructure > Graph Computing Frameworks (alongside RDFLib / TinkerPop).

It is a Python framework that gives one API over nine knowledge-graph backend families (NetworkX, RDF/SPARQL via rdflib, Cypher, REST, agent memory, and others) and validates each graph traversal against a declared ontology, rejecting semantically invalid hops at query time. Apache-2.0, documented, tested (pytest/ruff/mypy --strict/bandit via tox), demos run offline.