### PR TITLE
Add SSKG Hub (sustainability standards KG platform) to Other Domain

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -162,6 +162,7 @@
 * [Lynx](https://lynx-project.eu/) - an ecosystem of smart cloud services to better manage compliance, based on a Legal Knowledge Graph (LKG) which integrates and links heterogeneous compliance data sources including legislation, case law, standards and other private contracts.
 * [ResearchSpace](https://researchspace.org/) - A culture heritage knowledge graph from the British Museum. 
 * [Unified Medical Language System (UMLS)](https://www.nlm.nih.gov/research/umls/index.html) - The UMLS integrates and distributes key terminology, classification and coding standards, and associated resources to promote creation of more effective and interoperable biomedical information systems and services, including electronic health records.
+* [SSKG Hub](https://www.sskg-hub.com/) - An expert-guided platform that turns sustainability disclosure standards (GRI, SASB, TCFD, IFRS S2) into auditable, provenance-linked knowledge graphs, with LLM extraction, expert certification, and Neo4j storage ([paper](https://arxiv.org/abs/2603.00669)).
 * [DrugBank](https://go.drugbank.com/) - Knowledge base for drug interactions, pharmacology, chemical structures, targets, metabolism, and more. 
 * [STRING](https://string-db.org/) - A database of known and predicted protein-protein interactions.
 


### PR DESCRIPTION
Adds **SSKG Hub** to **Knowledge Graph Dataset → Other Domain**, alongside the domain KGs (Lynx, UMLS, DrugBank).

SSKG Hub is an expert-guided platform that turns sustainability disclosure standards (**GRI, SASB, TCFD, IFRS S2**) into auditable, provenance-linked knowledge graphs — LLM extraction produces a Draft KG that domain experts certify, stored in Neo4j. Live at https://www.sskg-hub.com/ · paper: https://arxiv.org/abs/2603.00669 (arXiv).

Anchored after UMLS to avoid overlapping my open PR #48 (different entry, both merge cleanly). Disclosure: I am an author.